### PR TITLE
ともだち登録時にクーポン配信

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
     ffi (1.12.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    httpclient (2.8.3)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     jbuilder (2.10.0)
@@ -199,6 +200,7 @@ DEPENDENCIES
   bootsnap
   coffee-rails
   dotenv-rails
+  httpclient
   jbuilder
   jquery-rails
   line-bot-api

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,6 @@ GEM
     ffi (1.12.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    httpclient (2.8.3)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     jbuilder (2.10.0)
@@ -200,7 +199,6 @@ DEPENDENCIES
   bootsnap
   coffee-rails
   dotenv-rails
-  httpclient
   jbuilder
   jquery-rails
   line-bot-api

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -22,9 +22,14 @@ class WebhookController < ApplicationController
     events.each { |event|
       case event
       when Line::Bot::Event::Follow
+        gajoen_API = GAJOEN_API::GetItem::Request.new(145)
+        response = gajoen_API.request
         message = {
           type: 'text',
-          text: '登録ありがとう！'
+          text: "登録ありがとう！
+          お礼にクーポンを送ります！
+          #{response['url']}
+          "
         }
         client.reply_message(event['replyToken'], message)
       when Line::Bot::Event::Message
@@ -32,7 +37,7 @@ class WebhookController < ApplicationController
         when Line::Bot::Event::MessageType::Text
           message = {
             type: 'text',
-            text: event.message['text']
+            text: 'test'
           }
           client.reply_message(event['replyToken'], message)
         when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -22,7 +22,7 @@ class WebhookController < ApplicationController
     events.each { |event|
       case event
       when Line::Bot::Event::Follow
-        gajoen_API = GajoenApi::GetItem::Request.new(145,56509)
+        gajoen_API = GajoenApi.new(145,56509)
         response = gajoen_API.request
         message = {
           type: 'text',

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -22,12 +22,18 @@ class WebhookController < ApplicationController
     events.each { |event|
       case event
       when Line::Bot::Event::Follow
-        gajoen_API = GajoenApi.new(145,56509)
-        response = gajoen_API.request
-        message = {
-          type: 'text',
-          text: "友だち追加ありがとうございます!\nPlanet CafeのLINE公式アカウントで、お気に入りのコーヒーとフードを見つけてみませんか。\n感謝の気持ちを込めてクーポンを送ります!\n是非お使いください!#{response['url']}"
-        }
+        response = GajoenApi.create_tickets(brand_id: 145, item_id: 56509)
+        if response != nil then
+          message = {
+            type: 'text',
+            text: "友だち追加ありがとうございます!\nPlanet CafeのLINE公式アカウントで、お気に入りのコーヒーとフードを見つけてみませんか。\n感謝の気持ちを込めてクーポンを送ります!\n是非お使いください!#{response['url']}"
+          }
+        else
+          message = {
+            type: 'text',
+            text: "友だち追加ありがとうございます!\nPlanet CafeのLINE公式アカウントで、お気に入りのコーヒーとフードを見つけてみませんか。"
+          }        
+        end
         client.reply_message(event['replyToken'], message)
       when Line::Bot::Event::Message
         case event.type

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -22,14 +22,11 @@ class WebhookController < ApplicationController
     events.each { |event|
       case event
       when Line::Bot::Event::Follow
-        gajoen_API = GAJOEN_API::GetItem::Request.new(145)
+        gajoen_API = GajoenApi::GetItem::Request.new(145,56509)
         response = gajoen_API.request
         message = {
           type: 'text',
-          text: "登録ありがとう！
-          お礼にクーポンを送ります！
-          #{response['url']}
-          "
+          text: "友だち追加ありがとうございます!\nPlanet CafeのLINE公式アカウントで、お気に入りのコーヒーとフードを見つけてみませんか。\n感謝の気持ちを込めてクーポンを送ります!\n是非お使いください!#{response['url']}"
         }
         client.reply_message(event['replyToken'], message)
       when Line::Bot::Event::Message
@@ -37,7 +34,7 @@ class WebhookController < ApplicationController
         when Line::Bot::Event::MessageType::Text
           message = {
             type: 'text',
-            text: 'test'
+            text: event.message['text']
           }
           client.reply_message(event['replyToken'], message)
         when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video

--- a/app/services/gajoen_API.rb
+++ b/app/services/gajoen_API.rb
@@ -23,7 +23,6 @@ class GajoenApi
     req['Authorization'] = "Bearer #{ENV['GAJOEN_HEADER']}"
     req['X-Giftee'] = 1
     req.set_form_data(@query)
-    p @query
     res = http.request(req)
     JSON.parse(res.body)
   end

--- a/app/services/gajoen_API.rb
+++ b/app/services/gajoen_API.rb
@@ -2,28 +2,30 @@ require 'net/https'
 require 'uri'
 require 'securerandom'
 
-module GAJOEN_API
-  module GetItem
-    class Request
-      attr_accessor :query
+class GajoenApi
+  attr_accessor :query
 
-      def initialize(brand_id)
-        request_code = SecureRandom.base64(50)
-        @url = ENV['GAJOEN_URI']+"/brands/#{brand_id}/tickets/#{request_code}"
-      end
-
-      def request
-        uri = URI.parse(@url)
-        http = Net::HTTP.new(uri.host, uri.port)
-        http.use_ssl = true
-        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-        req = Net::HTTP::Get.new(uri.request_uri)
-        req['Authorization'] = "Bearer #{ENV['GAJOEN_HEADER']}"
-        req['X-Giftee'] = 1
-        res = http.request(req)
-        JSON.parse(res.body)
-      end
-
-    end
+  def initialize(brand_id,item_id)
+    request_code = SecureRandom.urlsafe_base64(30)
+    @query={
+      "item_id"=>item_id,
+      "request_code"=>request_code
+    }
+    @url = ENV['GAJOEN_URI']+"/brands/#{brand_id}/tickets/"
   end
+
+  def request
+    uri = URI.parse(@url)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    req = Net::HTTP::Post.new(uri.request_uri)
+    req['Authorization'] = "Bearer #{ENV['GAJOEN_HEADER']}"
+    req['X-Giftee'] = 1
+    req.set_form_data(@query)
+    p @query
+    res = http.request(req)
+    JSON.parse(res.body)
+  end
+
 end

--- a/app/services/gajoen_API.rb
+++ b/app/services/gajoen_API.rb
@@ -3,28 +3,27 @@ require 'uri'
 require 'securerandom'
 
 class GajoenApi
-  attr_accessor :query
-
-  def initialize(brand_id,item_id)
+  def self.create_tickets(brand_id:, item_id:)
     request_code = SecureRandom.urlsafe_base64(30)
-    @query={
+    query={
       "item_id"=>item_id,
       "request_code"=>request_code
     }
-    @url = ENV['GAJOEN_URI']+"/brands/#{brand_id}/tickets/"
-  end
-
-  def request
-    uri = URI.parse(@url)
+    url = ENV['GAJOEN_URI']+"/brands/#{brand_id}/tickets/"
+    uri = URI.parse(url)
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true
     http.verify_mode = OpenSSL::SSL::VERIFY_NONE
     req = Net::HTTP::Post.new(uri.request_uri)
     req['Authorization'] = "Bearer #{ENV['GAJOEN_HEADER']}"
     req['X-Giftee'] = 1
-    req.set_form_data(@query)
+    req.set_form_data(query)
     res = http.request(req)
-    JSON.parse(res.body)
+    case res
+    when Net::HTTPSuccess
+      JSON.parse(res.body) 
+    else
+      nil
+    end
   end
-
 end

--- a/app/services/gajoen_API.rb
+++ b/app/services/gajoen_API.rb
@@ -1,0 +1,29 @@
+require 'net/https'
+require 'uri'
+require 'securerandom'
+
+module GAJOEN_API
+  module GetItem
+    class Request
+      attr_accessor :query
+
+      def initialize(brand_id)
+        request_code = SecureRandom.base64(50)
+        @url = ENV['GAJOEN_URI']+"/brands/#{brand_id}/tickets/#{request_code}"
+      end
+
+      def request
+        uri = URI.parse(@url)
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
+        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        req = Net::HTTP::Get.new(uri.request_uri)
+        req['Authorization'] = "Bearer #{ENV['GAJOEN_HEADER']}"
+        req['X-Giftee'] = 1
+        res = http.request(req)
+        JSON.parse(res.body)
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
## 実装の背景・目的

友達登録時にクーポンを配信する機能を作成した
データを入力したユーザに対してクーポンを配る機能作成のための前段階である
(ータを入力したユーザに対してクーポンを配る機能の作成予定は現段階ではない)

## やったこと

- gajeonAPIのgetを呼び出す処理の作成

## キャプチャ

![スクリーンショット 2021-08-18 18 35 57](https://user-images.githubusercontent.com/32125873/129875348-1ed8474c-c86b-4d0d-82b8-60c422f89065.png)



## 補足

- 友達登録したらメッセージ[登録してくれてありがとう]を送る
- 友達登録後、すぐにクーポンを配布(メッセージのところを変える)
- 友達登録したら、ユーザ登録
- 任意のタイミングでのクーポン配布
- DBに登録して配布した履歴の表示