### PR TITLE
DBに登録して配布した履歴の表示

### DIFF
--- a/app/controllers/coupons_controller.rb
+++ b/app/controllers/coupons_controller.rb
@@ -1,15 +1,24 @@
 class CouponsController < ApplicationController
   include LineConcern
   # GET /welcome
+  def index
+    coupons = Coupon.all()
+    flash[:notice] = ''
+    coupons.each do |coupon|
+      flash[:notice] << "内容: コーヒー50円引き, 日時: #{Time.at(coupon.created_at)}, ユーザ:#{coupon.user_id}\n"
+   end
+  end
+
   def create
-    users = User.where(enable: true).pluck(:line_id)
+    users = User.where(enable: true)
     users.each do |user|
       response = GajoenApi.create_tickets(brand_id: 145, item_id: 56509)
+      Coupon.create(user_id: user.id, item_id: response['item_id'], brand_id: response['brand_id'], coupon_url: response['url'], request_code: response['request_code'])
       message = {
         type: 'text',
         text: "日頃の感謝を込めてクーポンを配信します！是非お使いください！\n#{response['url']}"
       }
-      client.push_message(user, message)
+      client.push_message(user.line_id, message)
     end
     flash[:notice] = "#{users.count}件クーポンを配信しました。"
     redirect_to controller: :welcome

--- a/app/controllers/coupons_controller.rb
+++ b/app/controllers/coupons_controller.rb
@@ -1,6 +1,5 @@
 class CouponsController < ApplicationController
   include LineConcern
-  # GET /welcome
   def index
     @coupons = Coupon.all
   end
@@ -8,8 +7,9 @@ class CouponsController < ApplicationController
   def create
     users = User.where(enable: true)
     users.each do |user|
-      response = GajoenApi.create_tickets(brand_id: 145, item_id: 56509)
-      Coupon.create(user_id: user.id, item_id: response['item_id'], brand_id: response['brand_id'], coupon_url: response['url'], request_code: response['request_code'])
+      request_code = SecureRandom.urlsafe_base64(30)
+      response = GajoenApi.create_tickets(brand_id: 145, item_id: 56509, request_code: request_code)
+      Coupon.create!(user_id: user.id, item_id: response['item_id'], brand_id: response['brand_id'], coupon_url: response['url'], request_code: request_code)
       message = {
         type: 'text',
         text: "日頃の感謝を込めてクーポンを配信します！是非お使いください！\n#{response['url']}"

--- a/app/controllers/coupons_controller.rb
+++ b/app/controllers/coupons_controller.rb
@@ -2,11 +2,7 @@ class CouponsController < ApplicationController
   include LineConcern
   # GET /welcome
   def index
-    coupons = Coupon.all()
-    flash[:notice] = ''
-    coupons.each do |coupon|
-      flash[:notice] << "内容: コーヒー50円引き, 日時: #{Time.at(coupon.created_at)}, ユーザ:#{coupon.user_id}\n"
-   end
+    @coupons = Coupon.all
   end
 
   def create

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -22,7 +22,9 @@ class WebhookController < ApplicationController
           text: "友だち追加ありがとうございます!\nPlanet CafeのLINE公式アカウントで、お気に入りのコーヒーとフードを見つけてみませんか。"
         }       
         if user.enable
-          response = GajoenApi.create_tickets(brand_id: 145, item_id: 56509)
+          request_code = SecureRandom.urlsafe_base64(30)
+          response = GajoenApi.create_tickets(brand_id: 145, item_id: 56509, request_code: request_code)
+          Coupon.create!(user_id: user.id, item_id: response['item_id'], brand_id: response['brand_id'], coupon_url: response['url'], request_code: request_code)
           message[:text] = message[:text] + "\n感謝の気持ちを込めてクーポンを送ります!\n是非お使いください!#{response['url']}"
         else
           user.update!({enable: true})

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -1,2 +1,2 @@
-class Coupon < ActiveRecord::Base
+class Coupon < ApplicationRecord
 end

--- a/app/services/gajoen_API.rb
+++ b/app/services/gajoen_API.rb
@@ -3,8 +3,7 @@ require 'uri'
 require 'securerandom'
 
 class GajoenApi
-  def self.create_tickets(brand_id:, item_id:)
-    request_code = SecureRandom.urlsafe_base64(30)
+  def self.create_tickets(brand_id:, item_id:, request_code:)
     query={
       "item_id"=>item_id,
       "request_code"=>request_code
@@ -21,9 +20,7 @@ class GajoenApi
     res = http.request(req)
     case res
     when Net::HTTPSuccess
-      response = JSON.parse(res.body)
-      response['request_code'] = request_code
-      response
+      JSON.parse(res.body)
     else
       raise 'チケット発行に失敗しました。'
     end

--- a/app/services/gajoen_API.rb
+++ b/app/services/gajoen_API.rb
@@ -21,7 +21,9 @@ class GajoenApi
     res = http.request(req)
     case res
     when Net::HTTPSuccess
-      JSON.parse(res.body) 
+      response = JSON.parse(res.body)
+      response['request_code'] = request_code
+      response
     else
       raise 'チケット発行に失敗しました。'
     end

--- a/app/views/coupons/index.html.erb
+++ b/app/views/coupons/index.html.erb
@@ -1,14 +1,3 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>クーポン履歴</title>
-  <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
-  <%= stylesheet_link_tag  '//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css' %>
-  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-  <%= javascript_include_tag  '//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js' %>
-  <%= csrf_meta_tags %>
-</head>
-<body>
 <table class="table">
   <thead>
     <tr>
@@ -29,5 +18,4 @@
     <% end %>
   </tbody>
 </table>
-</body>
-</html>
+

--- a/app/views/coupons/index.html.erb
+++ b/app/views/coupons/index.html.erb
@@ -9,10 +9,25 @@
   <%= csrf_meta_tags %>
 </head>
 <body>
-    <% flash.each do |message_type, message| %>
-      <%= message %>
-    <% end %>
-<%= yield %>
+<table class="table">
+  <thead>
+    <tr>
+      <th>内容</th>
+      <th>時間</th>
+      <th>ユーザID</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
 
+  <tbody>
+    <% @coupons.each do |coupon| %>
+      <tr>
+        <td>コーヒー50円引き</td>
+        <td><%= Time.at(coupon.created_at) %></td>
+        <td><%= coupon.user_id %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
 </body>
 </html>

--- a/app/views/coupons/index.html.erb
+++ b/app/views/coupons/index.html.erb
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>クーポン履歴</title>
+  <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+  <%= stylesheet_link_tag  '//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css' %>
+  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
+  <%= javascript_include_tag  '//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js' %>
+  <%= csrf_meta_tags %>
+</head>
+<body>
+    <% flash.each do |message_type, message| %>
+      <%= message %>
+    <% end %>
+<%= yield %>
+
+</body>
+</html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Ruby Getting Started on Heroku</title>
+  <title>eGift Offer and Use Platform</title>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= stylesheet_link_tag  '//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css' %>
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>eGift Offer and Use Platform</title>
+  <title>eGift Attracting Customers Platform</title>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= stylesheet_link_tag  '//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css' %>
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,2 +1,3 @@
 
 <%= button_to 'クーポンを配る', {controller: 'coupons', :action => "create"}, {:method => :post} %>
+<%= button_to 'クーポン履歴をみる', {controller: 'coupons', :action => "index"}, {:method => :get} %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,5 @@ Rails.application.routes.draw do
   # for LINE webhook
   post '/callback' => 'webhook#callback'
   post '/create' => 'coupons#create'
+  get '/index' => 'coupons#index'
 end

--- a/db/migrate/20210819054816_create_users.rb
+++ b/db/migrate/20210819054816_create_users.rb
@@ -10,5 +10,6 @@ class CreateUsers < ActiveRecord::Migration[6.0]
 
       t.timestamps
     end
+    add_index :users, :line_id, :unique => true
   end
 end

--- a/db/migrate/20210820023527_create_coupons.rb
+++ b/db/migrate/20210820023527_create_coupons.rb
@@ -9,5 +9,7 @@ class CreateCoupons < ActiveRecord::Migration[6.0]
 
       t.timestamps
     end
+    add_index :coupons, :request_code, :unique => true
+    add_index :coupons, :coupon_url, :unique => true
   end
 end

--- a/db/migrate/20210820023527_create_coupons.rb
+++ b/db/migrate/20210820023527_create_coupons.rb
@@ -1,0 +1,13 @@
+class CreateCoupons < ActiveRecord::Migration[6.0]
+  def change
+    create_table :coupons do |t|
+      t.references :user, foreign_key: true
+      t.string :item_id, :null => false
+      t.string :brand_id, :null => false
+      t.string :request_code, :null => false, :unique => true
+      t.string :coupon_url, :null => false, :unique => true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -23,6 +23,8 @@ ActiveRecord::Schema.define(version: 2021_08_20_023527) do
     t.string "coupon_url", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["coupon_url"], name: "index_coupons_on_coupon_url", unique: true
+    t.index ["request_code"], name: "index_coupons_on_request_code", unique: true
     t.index ["user_id"], name: "index_coupons_on_user_id"
   end
 
@@ -35,6 +37,7 @@ ActiveRecord::Schema.define(version: 2021_08_20_023527) do
     t.boolean "enable", default: true
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["line_id"], name: "index_users_on_line_id", unique: true
   end
 
   create_table "widgets", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_19_054816) do
+ActiveRecord::Schema.define(version: 2021_08_20_023527) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "coupons", force: :cascade do |t|
+    t.bigint "user_id"
+    t.string "item_id", null: false
+    t.string "brand_id", null: false
+    t.string "request_code", null: false
+    t.string "coupon_url", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_coupons_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "line_id", null: false
@@ -34,4 +45,5 @@ ActiveRecord::Schema.define(version: 2021_08_19_054816) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "coupons", "users"
 end


### PR DESCRIPTION
## 実装の背景・目的

セグメントを分けてクーポンを配布した後に、履歴を見るための基本実装である。
テーブル形式で表示した。

## やったこと

- 任意のタイミングでクーポンを配った時にDBに格納
- テーブル作成
- クーポン発行したuserごとにDB格納
- 発行したURLも持っていた(格納した)ほうが良い？
- とりあえず発行したクーポンごとにまとめて表示ではなく、発行したユーザ-クーポンが全て出てくる形にする

## キャプチャ

![スクリーンショット 2021-08-20 14 00 25](https://user-images.githubusercontent.com/32125873/130181822-a87e179d-1275-4829-af24-92b563373446.png)


## 補足

- 本番にあげる
- 発表資料を書く
